### PR TITLE
21 - Hinweismeldung bei Änderung des Rechnungsdatums

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.sg.computerinsel</groupId>
     <artifactId>kassenbuch</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>tools</name>
@@ -61,6 +61,7 @@
             <groupId>com.itextpdf</groupId>
             <artifactId>itextpdf</artifactId>
             <version>5.0.6</version>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>

--- a/readme.txt
+++ b/readme.txt
@@ -133,3 +133,12 @@ V 1.1.1:
 ** XX - Umstellung - Auslesen des Rechnungsbetrags geändert **
 - Der Rechnungsbetrag wurde in den HTML-Rechnungen verschoben. Es wird nun automatisch erkannt, ob sich der Rechnungsbetrag an erster oder letzter
 Stelle im Gesamtergebnis befindet.
+
+V 1.1.2
+** 21 - Hinweismeldung bei Änderung des Rechnungsdatums **
+- Wird das Rechnungsdatum von zu einem anderem Datum als dem Tagesdatum geändert wird das Feld Ausgangsbetrag rot markiert.
+Zudem wird das Datum im Feld Ausgangsbetragsdatum auf den Wert des Feldes Rechnungsdatum von gesetzt.
+Wird ein anderes Feld fokussiert erscheint eine Hinweismeldung, dass der Ausgangsbetrag angepasst werden muss.
+
+** XX - Verbesserung Meldungsdialoge **
+- Nach dem Speichern des Kassenbuchs erscheint nun nur noch ein Meldungsdialog. Zudem wurden die Dialoge optisch verbessert.

--- a/src/main/java/de/sg/computerinsel/tools/kassenbuch/KassenbuchErstellenUtils.java
+++ b/src/main/java/de/sg/computerinsel/tools/kassenbuch/KassenbuchErstellenUtils.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -45,6 +46,8 @@ public final class KassenbuchErstellenUtils {
     private static final String FORMAT_DATUM = "dd.MM.yyyy";
 
     public static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat(FORMAT_DATUM);
+
+    public static final DateTimeFormatter DATETIME_FORMAT = DateTimeFormatter.ofPattern(FORMAT_DATUM);
 
     public static final SimpleDateFormat DATE_FORMAT_FILES = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
 
@@ -202,7 +205,8 @@ public final class KassenbuchErstellenUtils {
         for (final Rechnung rechnung : rechnungen) {
             final String verwendungszweck = StringUtils.isNumeric(rechnung.getRechnungsnummer())
                     || StringUtils.isNumeric(StringUtils.substring(rechnung.getRechnungsnummer(), 1))
-                            ? "Rechnung: " + rechnung.getRechnungsnummer() : rechnung.getRechnungsnummer();
+                            ? "Rechnung: " + rechnung.getRechnungsnummer()
+                            : rechnung.getRechnungsnummer();
             final String formattedRechnungsbetrag = BETRAG_FORMAT.format(rechnung.getRechnungsbetrag());
             gesamtBetrag = gesamtBetrag.add(rechnung.getRechnungsbetrag());
             gesamtEingang = isEingangssbetrag(formattedRechnungsbetrag) ? gesamtEingang.add(rechnung.getRechnungsbetrag()) : gesamtEingang;


### PR DESCRIPTION
* Entspricht das Rechnungsdatum von nicht dem Tagesdatum wird das Feld Ausgangsbetrag rot markiert und Ausgangsbetrag vom auf das Rechnungsdatum von gesetzt
* Anpassung Meldungsdialoge
* Meldung, dass das Kassenbuch gespeichert wurde nur ein mal anzeigen